### PR TITLE
Add pipx installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ cd Port2ctee
 pip install .
 ```
 
+Alternatively, you can use **pipx** to install it in an isolated
+environment:
+
+```bash
+pipx install git+<repo-url>
+```
+
 For local development, use:
 
 ```bash


### PR DESCRIPTION
## Summary
- document pipx as an alternative installation method

## Testing
- `python -m py_compile port2ctree.py`
- `python -m py_compile setup.py`
- `python port2ctree.py -h`

------
https://chatgpt.com/codex/tasks/task_e_6859999c6f7c8329bf9085632a513ce2