### PR TITLE
Fix read only nodes

### DIFF
--- a/port2ctree.py
+++ b/port2ctree.py
@@ -24,9 +24,9 @@ def generate_ctd(ports, output_file):
     with open(output_file, 'w', encoding='utf-8') as f:
         f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
         f.write('<cherrytree>\n')
-        f.write('  <node name="Open Ports" custom_icon_id="0">\n')
+        f.write('  <node name="Open Ports" read_only="false" custom_icon_id="0">\n')
         for port, proto, service in ports:
-            f.write(f'    <node name="Port {port}/{proto} - {service}" custom_icon_id="0">\n')
+            f.write(f'    <node name="Port {port}/{proto} - {service}" read_only="false" custom_icon_id="0">\n')
             f.write('      <rich_text><![CDATA[\n')
             f.write(f'<b>Port:</b> {port}<br/>\n')
             f.write(f'<b>Protocol:</b> {proto}<br/>\n')


### PR DESCRIPTION
## Summary
- allow pasting images by writing `read_only="false"` when generating cherrytree nodes

## Testing
- `python3 -m py_compile port2ctree.py`


------
https://chatgpt.com/codex/tasks/task_e_6859a1c2dd5c83299b0a34057bfdbd64