### PR TITLE
Fix node type for Open Ports

### DIFF
--- a/port2ctree.py
+++ b/port2ctree.py
@@ -25,6 +25,7 @@ def generate_ctd(ports, output_file):
         f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
         f.write('<cherrytree>\n')
         f.write('  <node name="Open Ports" read_only="false" custom_icon_id="0">\n')
+        f.write('    <rich_text><![CDATA[]]></rich_text>\n')
         for port, proto, service in ports:
             f.write(f'    <node name="Port {port}/{proto} - {service}" read_only="false" custom_icon_id="0">\n')
             f.write('      <rich_text><![CDATA[\n')


### PR DESCRIPTION
## Summary
- ensure generated Open Ports node is rich text

## Testing
- `python3 -m py_compile port2ctree.py`


------
https://chatgpt.com/codex/tasks/task_e_6859a3c0a8848329a85786d44bc6f78a