### PR TITLE
Fix rich text rendering for generated nodes

### DIFF
--- a/port2ctree.py
+++ b/port2ctree.py
@@ -27,7 +27,7 @@ def generate_ctd(ports, output_file):
         f.write('  <node name="Open Ports" read_only="false" custom_icon_id="0">\n')
         f.write('    <rich_text><![CDATA[]]></rich_text>\n')
         for port, proto, service in ports:
-            f.write(f'    <node name="Port {port}/{proto} - {service}" read_only="false" custom_icon_id="0">\n')
+            f.write(f'    <node name="Port {port}/{proto} - {service}" read_only="false" custom_icon_id="0" type="rich_text">\n')
             f.write('      <rich_text><![CDATA[\n')
             f.write(f'<b>Port:</b> {port}<br/>\n')
             f.write(f'<b>Protocol:</b> {proto}<br/>\n')


### PR DESCRIPTION
## Summary
- ensure generated nodes in `port2ctree.py` have `type="rich_text"`

## Testing
- `python3 -m py_compile port2ctree.py`


------
https://chatgpt.com/codex/tasks/task_e_6859a866a1ec832994c63c4d6d1fb26b