### PR TITLE
Fix root node text type

### DIFF
--- a/port2ctree.py
+++ b/port2ctree.py
@@ -24,7 +24,7 @@ def generate_ctd(ports, output_file):
     with open(output_file, 'w', encoding='utf-8') as f:
         f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
         f.write('<cherrytree>\n')
-        f.write('  <node name="Open Ports" read_only="false" custom_icon_id="0">\n')
+        f.write('  <node name="Open Ports" read_only="false" custom_icon_id="0" type="rich_text">\n')
         f.write('    <rich_text><![CDATA[]]></rich_text>\n')
         for port, proto, service in ports:
             f.write(f'    <node name="Port {port}/{proto} - {service}" read_only="false" custom_icon_id="0" type="rich_text">\n')


### PR DESCRIPTION
## Summary
- set the root node to rich text so images can be pasted

## Testing
- `python3 port2ctree.py --help`
- `python3 port2ctree.py scan.txt`

------
https://chatgpt.com/codex/tasks/task_e_6859aa91cda08329bfffb0d53eac13ec