### PR TITLE
Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,8 @@ jobs:
           python -m build
 
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m pip install twine
+          twine upload dist/*


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use Twine for PyPI upload

## Testing
- `python -m pip install -e .` *(fails: Operation cancelled by user due to network restrictions)*
- `python -m py_compile port2ctree/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68602eb2669083298956f1c1f7a9e7b4