### PR TITLE
Fix indentation in workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
+          with:
+            python-version: '3.x'
 
       - name: Install build tools
         run: |
@@ -29,8 +29,8 @@ jobs:
         run: |
           python -m build
 
-     - name: Publish distribution 📦 to TestPyPI
-       uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish distribution 📦 to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
           with:
             user: __token__
             password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- align `with:` block indentation under `uses:` in python-publish workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686104589408832988152ec658f3f6f6