### PR TITLE
Add repository URL for PyPI action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,4 +34,5 @@ jobs:
           with:
             user: __token__
             password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+            repository-url: https://test.pypi.org/legacy/
             


### PR DESCRIPTION
## Summary
- point GitHub publish action to TestPyPI

## Testing
- `git diff --cached --color --stat`

------
https://chatgpt.com/codex/tasks/task_e_686108e13720832984b22c3438e1cb99