### PR TITLE
Fix packaging configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="port2ctree",
     version="1.0",
-    py_modules=["port2ctree"],
+    packages=["port2ctree"],
     entry_points={
         "console_scripts": [
             "port2ctree=port2ctree:main",


### PR DESCRIPTION
## Summary
- package `port2ctree` instead of a single module
- support setuptools package discovery

## Testing
- `python -m build` *(fails: No module named build)*

------
https://chatgpt.com/codex/tasks/task_e_68610c891db48329816b45aa3448e1cc