### PR TITLE
Fix YAML indentation in publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
-          with:
-            python-version: '3.x'
+        with:
+          python-version: '3.x'
 
       - name: Install build tools
         run: |
@@ -31,8 +31,8 @@ jobs:
 
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-          with:
-            user: __token__
-            password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-            repository-url: https://test.pypi.org/legacy/
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
             


### PR DESCRIPTION
## Summary
- fix indentation for `with` statements in Python publish workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686119d95c3083299eb88f0f41a4bab1