### PR TITLE
Fix OIDC token retrieval for PyPI publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build-and-publish-test:


### PR DESCRIPTION
## Summary
- enable id-token permission in CI workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611c3645d88329977dbb4413cefa6b